### PR TITLE
Add socks proxy support for boris-client

### DIFF
--- a/boris-client/boris-client.cabal
+++ b/boris-client/boris-client.cabal
@@ -85,12 +85,15 @@ executable boris
                     , async
                     , conduit
                     , conduit-extra
+                    , connection                      == 0.2.*
+                    , data-default                    == 0.5.*
                     , http-client
+                    , http-client-tls                 == 0.2.2.*
+                    , old-locale
                     , optparse-applicative            == 0.11.*
                     , text
                     , time
                     , transformers
-                    , old-locale
 
 test-suite test-io
   type:


### PR DESCRIPTION
If you set `SOCKS_PROXY=localhost:6666` you can now run `boris` through the standard CI tunnel.

/cc @markhibberd @nhibberd @charleso @olorin 
