### PR TITLE
Soften discover semantics.

### DIFF
--- a/boris-service/test/Test/IO/Boris/Service/Git.hs
+++ b/boris-service/test/Test/IO/Boris/Service/Git.hs
@@ -10,6 +10,7 @@ import qualified Boris.Service.Git as Git
 
 import qualified Data.Conduit.Binary as CB
 import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
 import qualified Data.Text.IO as T
 
 import           Disorder.Core.IO
@@ -91,6 +92,145 @@ prop_initialise i =
       Git.initialise o e w build (Repository . T.pack $ repository) Nothing
 
     pure $ result === (Right $ BuildInstance (Specification build [Command "tsar" ["pre"]] [Command "echo" ["test"]] [] [Command "tsar" ["success"]] [Command "tsar" ["failure"]]) (Ref "refs/heads/test") (Commit "7d4324a0cb9bb7bd0e627d6ea86dbe02aa31be62"))
+
+
+
+prop_discovering i =
+  testIO . withSystemTempDirectory "workspace" $ \t -> do
+    let
+      o = CB.sinkHandle stdout
+      e = CB.sinkHandle stderr
+      repository = t </> "git"
+      path = WorkspacePath . T.pack . (</> "workspace") $ t
+
+    D.createDirectoryIfMissing True repository
+
+    setEnv "GIT_AUTHOR_DATE" "1970-01-01 00:00:00 +0000"
+    setEnv "GIT_AUTHOR_NAME" "quick"
+    setEnv "GIT_AUTHOR_EMAIL" "quick@email"
+    setEnv "GIT_COMMITTER_DATE" "1970-01-01 00:00:00 +0000"
+    setEnv "GIT_COMMITTER_NAME" "check"
+    setEnv "GIT_COMMITTER_EMAIL" "check@mail"
+
+    flail $
+      X.exec o e $ (proc "git" ["init"]) { cwd = Just repository }
+
+    T.writeFile (repository </> "README.md") "This is a test."
+
+    flail $
+      X.exec o e $ (proc "git" ["add", "-A", "README.md"]) { cwd = Just repository }
+
+    flail $
+      X.exec o e $ (proc "git" ["commit", "-m", "first"]) { cwd = Just repository }
+
+    --
+    -- We want to test 4 scenarios:
+    --
+    --  1) No boris-git.toml at all, should just find nothing.
+    --  2) A boris-git.toml, but no boris.toml, should just find nothing.
+    --  3) A boris-git.toml, a boris.toml, but no build yet, should just find nothing.
+    --  4) A boris-git.toml, a boris.toml, a matching build, should find this ref.
+    --
+
+
+    --
+    -- (1) No boris-git.toml at all, should just find nothing.
+    --
+    scenario1 <- runEitherT . withWorkspace path i $ \w -> do
+      Git.discovering o e w (Repository . T.pack $ repository)
+
+    --
+    -- Set up boris-git.toml for (2), (3) and (4).
+    --
+
+    T.writeFile (repository </> "boris-git.toml") "\
+      \[boris] \n\
+      \  version = 1 \n\
+      \\n\
+      \[build.test]\n\
+      \  git = \"refs/heads/test\"\n\
+      \[build.no-test-yet]\n\
+      \  git = \"refs/heads/no-test-yet\"\n\
+      \[build.no-boris-yet]\n\
+      \  git = \"refs/heads/no-boris-yet\"\n\
+      \\n"
+
+    flail $
+      X.exec o e $ (proc "git" ["add", "-A", "boris-git.toml"]) { cwd = Just repository }
+
+    flail $
+      X.exec o e $ (proc "git" ["commit", "-m", "boris-git"]) { cwd = Just repository }
+
+    --
+    -- (2) A boris-git.toml, but no boris.toml, should just find nothing.
+    --
+
+    flail $
+      X.exec o e $ (proc "git" ["checkout", "-b", "no-boris-yet"]) { cwd = Just repository }
+    T.writeFile (repository </> "not-boris-related") ""
+
+    flail $
+      X.exec o e $ (proc "git" ["add", "-A", "not-boris-related"]) { cwd = Just repository }
+
+    flail $
+      X.exec o e $ (proc "git" ["commit", "-m", "not-boris-related"]) { cwd = Just repository }
+
+    scenario2 <- runEitherT . withWorkspace path i $ \w -> do
+      Git.discovering o e w (Repository . T.pack $ repository)
+
+    --
+    -- (3) A boris-git.toml, a boris.toml, but no build yet, should just find nothing.
+    --
+
+    flail $
+      X.exec o e $ (proc "git" ["checkout", "-b", "no-test-yet"]) { cwd = Just repository }
+
+    T.writeFile (repository </> "boris.toml") "\
+      \[boris]\n\
+      \  version = 1\n\
+      \\n"
+
+    flail $
+      X.exec o e $ (proc "git" ["add", "-A", "boris.toml"]) { cwd = Just repository }
+
+    flail $
+      X.exec o e $ (proc "git" ["commit", "-m", "test"]) { cwd = Just repository }
+
+    scenario3 <- runEitherT . withWorkspace path i $ \w -> do
+      Git.discovering o e w (Repository . T.pack $ repository)
+
+    --
+    -- (4) A boris-git.toml, a boris.toml, a matching build, should find this ref.
+    --
+
+    flail $
+      X.exec o e $ (proc "git" ["checkout", "-b", "test"]) { cwd = Just repository }
+
+    T.writeFile (repository </> "boris.toml") "\
+      \[boris]\n\
+      \  version = 1\n\
+      \\n\
+      \[build.test]\n\
+      \  command = [[\"echo\", \"test\"]]\n\
+      \\n"
+
+    flail $
+      X.exec o e $ (proc "git" ["add", "-A", "boris.toml"]) { cwd = Just repository }
+
+    flail $
+      X.exec o e $ (proc "git" ["commit", "-m", "test"]) { cwd = Just repository }
+
+    scenario4 <- runEitherT . withWorkspace path i $ \w -> do
+      Git.discovering o e w (Repository . T.pack $ repository)
+
+    (commit, _, _) <- X.capture o e $ (proc "git" ["rev-parse", "refs/heads/test"]) { cwd = Just repository }
+
+    pure $ conjoin [
+        scenario1 === Right []
+      , scenario2 === Right []
+      , scenario3 === Right []
+      , scenario4 === Right [DiscoverInstance (BuildPattern (Build "test") (Pattern "refs/heads/test")) (Ref "refs/heads/test") (Commit . T.strip . T.decodeUtf8 $ commit)]
+      ]
 
 flail :: IO ExitCode -> IO ()
 flail cc =


### PR DESCRIPTION
The previous approach was a bit brute force, it just
tried and bailed out if it couldn't find the right
one. This resulted in:
- More than necessary bail outs.
- More than necessary builds (as it wasn't cross
  checking validity, just firing them to build to
  worry about).

This new approach does a deep check on build existence.

It also adds a comprehensive test for all the discover
scenarios.

@nhibberd This will fix the scenario we discussed yesterday, where the bail outs were causing you issues on nodes with lots of workers.
