### PR TITLE
boris-http: set content-type to "plain-text; charset=utf-8" for log

### DIFF
--- a/boris-http/boris-http.cabal
+++ b/boris-http/boris-http.cabal
@@ -37,6 +37,7 @@ library
                     , containers                      == 0.5.*
                     , file-embed                      == 0.0.*
                     , lens                            >= 4.6        && < 4.9
+                    , http-media                      == 0.6.*
                     , http-types                      == 0.8.*
                     , mmorph                          == 1.0.*
                     , resourcet                       == 1.1.*

--- a/boris-http/src/Boris/Http/Resource/Log.hs
+++ b/boris-http/src/Boris/Http/Resource/Log.hs
@@ -15,7 +15,7 @@ import qualified Boris.Store.Build as SB
 
 import           Blaze.ByteString.Builder (fromByteString)
 
-import           Charlotte.Airship (withVersionJson)
+import           Charlotte.Airship (Versioned, withVersion')
 
 import           Data.Conduit (Source, (=$=), runConduit)
 import qualified Data.Conduit.List as CL
@@ -28,6 +28,7 @@ import qualified Jebediah.Conduit as J
 import           Mismi (runAWST, renderError)
 import           Mismi.Amazonka (Env)
 
+import           Network.HTTP.Media.MediaType (MediaType)
 import qualified Network.HTTP.Types as HTTP
 
 import           P
@@ -41,7 +42,7 @@ item env e =
            HTTP.methodGet
          ]
 
-    , contentTypesProvided = pure . withVersionJson $ \v -> case v of
+    , contentTypesProvided = pure . withVersionText $ \v -> case v of
         V1 -> do
           i <- getBuildId
 
@@ -60,6 +61,10 @@ item env e =
                     send (fromByteString "\n")
                     flush)
     }
+
+withVersionText :: Versioned v => (v -> a) -> [(MediaType, a)]
+withVersionText r =
+  [("text/plain; charset=utf-8", r maxBound)] <> withVersion' r
 
 source :: Env -> LogData -> Source IO Text
 source env (LogData gname sname) =


### PR DESCRIPTION
Previously the default content-type was `application/json`, which I could live with except that the charset isn't being set so my browser interprets the payload as latin1 and logs come out a bit weird sometimes.

This keeps the versioned content-type as well, but not sure if it's relevant here? I don't know. It's a bit odd that it says it's [json](https://github.com/ambiata/boris/blob/master/boris-http/src/Boris/Http/Version.hs) when it doesn't return json.

I don't really mind how this gets done but would really like the utf-8 charset in there so that logs display correctly.

/cc @markhibberd @nhibberd @charleso 
