### PR TITLE
Actually display time zone offset

### DIFF
--- a/boris-http/src/Boris/Http/Html/Template.hs
+++ b/boris-http/src/Boris/Http/Html/Template.hs
@@ -28,8 +28,8 @@ import           Boris.Queue (QueueSize (..))
 
 import           Data.Map (Map)
 import qualified Data.Map as M
-import           Data.Time (UTCTime, diffUTCTime, formatTime, defaultTimeLocale)
-import           Data.Time.Zones (utcToLocalTimeTZ)
+import           Data.Time (UTCTime, ZonedTime(..), diffUTCTime, formatTime, defaultTimeLocale)
+import           Data.Time.Zones (utcToLocalTimeTZ, timeZoneForUTCTime)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 
@@ -137,8 +137,8 @@ build l b =
     renderPage <$> renderTemplate (defaultState `usingContext` context) build'
 
 renderTime :: ClientLocale -> UTCTime -> Text
-renderTime l =
-  T.pack . formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%z" . utcToLocalTimeTZ (clientLocaleTZ l)
+renderTime (ClientLocale tz) t =
+  T.pack . formatTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%z" $ ZonedTime (utcToLocalTimeTZ tz t) (timeZoneForUTCTime tz t)
 
 renderDuration :: UTCTime -> UTCTime -> Text
 renderDuration s e =


### PR DESCRIPTION
`utcToLocalTimeTZ` strips out time zone info
