### PR TITLE
Sort refs by latest build.

### DIFF
--- a/boris-http/template/builds.hbs
+++ b/boris-http/template/builds.hbs
@@ -25,11 +25,11 @@
               {{/each}}
             </div>
             {{/if}}
-            {{#each refs as |key val|}}
+            {{#each refs}}
             <div>
-              <h4>{{key}}</h4>
+              <h4>{{this.name}}</h4>
               <div>
-              {{#each val}}
+              {{#each this.builds}}
                 <span>
                   <a href="/build/{{this}}">#{{this}}</a>
                 </span>


### PR DESCRIPTION
Before:

<img width="703" alt="screen shot 2016-08-30 at 7 09 00 pm" src="https://cloud.githubusercontent.com/assets/22832/18083146/3d7a7d66-6ee5-11e6-887f-50fb8b1e6455.png">

After:

<img width="714" alt="screen shot 2016-08-30 at 7 07 07 pm" src="https://cloud.githubusercontent.com/assets/22832/18083124/1153ea2e-6ee5-11e6-9118-5e025e2e22cc.png">

Related to comment in - https://github.com/ambiata/boris/issues/116

This has been discussed a fair bit. I don't want to have separate pages or pagination. This captures intent of what page was meant to be better. At some point we may want to expire things out of index but that is more an indexing question that UI.
