### PR TITLE
Add asset middleware for readonly http

### DIFF
--- a/boris-http/main/boris-http-readonly.hs
+++ b/boris-http/main/boris-http-readonly.hs
@@ -6,6 +6,7 @@ import           Agriculture (agriculture)
 
 import           Boris.Core.Data
 import           Boris.Http.Config
+import qualified Boris.Http.Resource.Static as Static
 import           Boris.Http.Data
 import           Boris.Http.Route (borisReadonly)
 import qualified Boris.Store.Lifecycle as SL
@@ -34,5 +35,6 @@ main = do
   orDie renderError $ runAWS env $ SL.initialise e
 
   runStopFile (lookupEnv "BORIS_HTTP_STOP") $ \pin -> do
-    agriculture pin "boris-http-readonly" buildInfoVersion $ do
-      return $ resourceToWai defaultAirshipConfig (borisReadonly env e c) (resource404 ())
+    agriculture pin "boris-http-readonly" buildInfoVersion $
+      return . ($) Static.staticMiddleware $
+        resourceToWai defaultAirshipConfig (borisReadonly env e c) (resource404 ())


### PR DESCRIPTION
! @sphvn @nhibberd 

Currently the wallboard is broken because the now required assets weren't supported by the readonly executable.